### PR TITLE
`addNewOrSave` public method was added

### DIFF
--- a/SwiftyPlistManager/SwiftyPlistManager.swift
+++ b/SwiftyPlistManager/SwiftyPlistManager.swift
@@ -239,6 +239,14 @@ public class SwiftyPlistManager {
     }
   }
   
+  public func addNewOrSave(_ value: Any, forKey: String, toPlistWithName: String, completion:(_ error :SwiftyPlistManagerError?) -> ()) {
+    if keyAlreadyExists(key: forKey, inPlistWithName: toPlistWithName){
+        save(value, forKey: forKey, toPlistWithName: toPlistWithName, completion: completion)
+    }else{
+        addNew(value, key: forKey, toPlistWithName: toPlistWithName, completion: completion)
+    }
+  }
+    
   public func save(_ value: Any, forKey: String, toPlistWithName: String, completion:(_ error :SwiftyPlistManagerError?) -> ()) {
     
     if let plist = Plist(name: toPlistWithName) {


### PR DESCRIPTION
It is often the case that if a key does not exist, then create the key-value pair, if it exists, modify it. Provide a new method addNewOrSave, in fact, it is just a wrapper of the addNew and save methods